### PR TITLE
Fix deadlock when calling .Wait() by changing interface to async.

### DIFF
--- a/Gofer.NET.Tests/GivenARedisTaskQueue.cs
+++ b/Gofer.NET.Tests/GivenARedisTaskQueue.cs
@@ -78,7 +78,6 @@ namespace Gofer.NET.Tests
                 TC(() => ArrayFunc3(new int?[] {1, 2, 3, null, 5}, semaphoreFile), "1,2,3,null,5"),
                 
                 // Awaiting inside the lambda is unnecessary, as the method is extracted and serialized.
-                TC(() => AsyncFunc(semaphoreFile).Wait(), "async"),
 #pragma warning disable 4014
                 TC(() => AsyncFunc(semaphoreFile), "async"),
                 TC(() => AsyncFuncThatReturnsString(semaphoreFile), "async")

--- a/Gofer.NET.Tests/GivenARedisTaskQueue.cs
+++ b/Gofer.NET.Tests/GivenARedisTaskQueue.cs
@@ -78,6 +78,7 @@ namespace Gofer.NET.Tests
                 TC(() => ArrayFunc3(new int?[] {1, 2, 3, null, 5}, semaphoreFile), "1,2,3,null,5"),
                 
                 // Awaiting inside the lambda is unnecessary, as the method is extracted and serialized.
+                TC(() => AsyncFunc(semaphoreFile).Wait(), "async"),
 #pragma warning disable 4014
                 TC(() => AsyncFunc(semaphoreFile), "async"),
                 TC(() => AsyncFuncThatReturnsString(semaphoreFile), "async")

--- a/Gofer.NET.Utils/TaskInfo.cs
+++ b/Gofer.NET.Utils/TaskInfo.cs
@@ -61,7 +61,7 @@ namespace Gofer.NET.Utils
                 return staticMethod.Invoke(null, Args);
             }
             
-            var instanceMethod = type.GetMethod(MethodName, 
+            var instanceMethod = type.GetMethod(MethodName,
                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             
             if (instanceMethod == null)

--- a/TaskScheduler.cs
+++ b/TaskScheduler.cs
@@ -59,29 +59,29 @@ namespace Gofer.NET
             }
         }
 
-        public void AddScheduledTask(Expression<Action> action, TimeSpan offsetFromNow, string taskName)
+        public async Task AddScheduledTask(Expression<Action> action, TimeSpan offsetFromNow, string taskName)
         {
-            AddTaskToSchedule(new TaskSchedule(action.ToTaskInfo(), offsetFromNow, _taskQueue.Backend, false, taskName));
+            await AddTaskToSchedule(new TaskSchedule(action.ToTaskInfo(), offsetFromNow, _taskQueue.Backend, false, taskName));
         }
 
-        public void AddScheduledTask(Expression<Action> action, DateTimeOffset offsetFromNow, string taskName)
+        public async Task AddScheduledTask(Expression<Action> action, DateTimeOffset offsetFromNow, string taskName)
         {
-            AddTaskToSchedule(new TaskSchedule(action.ToTaskInfo(), offsetFromNow, _taskQueue.Backend, false, taskName));
+            await AddTaskToSchedule(new TaskSchedule(action.ToTaskInfo(), offsetFromNow, _taskQueue.Backend, false, taskName));
         }
 
-        public void AddScheduledTask(Expression<Action> action, DateTime scheduledTime, string taskName)
+        public async Task AddScheduledTask(Expression<Action> action, DateTime scheduledTime, string taskName)
         {
-            AddTaskToSchedule(new TaskSchedule(action.ToTaskInfo(), scheduledTime, _taskQueue.Backend, false, taskName));
+            await AddTaskToSchedule(new TaskSchedule(action.ToTaskInfo(), scheduledTime, _taskQueue.Backend, false, taskName));
         }
 
-        public void AddRecurringTask(Expression<Action> action, TimeSpan interval, string taskName)
+        public async Task AddRecurringTask(Expression<Action> action, TimeSpan interval, string taskName)
         {
-            AddTaskToSchedule(new TaskSchedule(action.ToTaskInfo(), interval, _taskQueue.Backend, true, taskName));
+            await AddTaskToSchedule(new TaskSchedule(action.ToTaskInfo(), interval, _taskQueue.Backend, true, taskName));
         }
 
-        public void AddRecurringTask(Expression<Action> action, string crontab, string taskName)
+        public async Task AddRecurringTask(Expression<Action> action, string crontab, string taskName)
         {
-            AddTaskToSchedule(new TaskSchedule(action.ToTaskInfo(), crontab, _taskQueue.Backend, taskName));
+            await AddTaskToSchedule(new TaskSchedule(action.ToTaskInfo(), crontab, _taskQueue.Backend, taskName));
         }
 
         public void RemoveScheduledTask(string taskName)
@@ -94,10 +94,11 @@ namespace Gofer.NET
             RemoveTaskFromSchedule(_scheduledTasks[taskName]);
         }
 
-        private void AddTaskToSchedule(TaskSchedule taskSchedule)
+        private async Task AddTaskToSchedule(TaskSchedule taskSchedule)
         {
             _scheduledTasks[taskSchedule.TaskKey] = taskSchedule;
-            taskSchedule.ClearLastRunTime().Wait();
+            
+            await taskSchedule.ClearLastRunTime();
 
 //            var jsonTaskSchedule = JsonTaskInfoSerializer.Serialize(taskSchedule);
 //            _taskQueue.Backend.AddToList(ScheduleBackupKey, jsonTaskSchedule);


### PR DESCRIPTION
Calling .AddScheduledTask inside an ASP.NET Request context was causing deadhangs.

Fix that by propagating all async calls to the interface, and let the caller handle synchronous execution when necessary.

Good Source for understanding:
http://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
