### PR TITLE
Use TaskKey object rather than string

### DIFF
--- a/Gofer.NET.Tests/GivenARecurringTask.cs
+++ b/Gofer.NET.Tests/GivenARecurringTask.cs
@@ -15,7 +15,8 @@ namespace Gofer.NET.Tests
         [Fact]
         public void ItPersistsPropertiesWhenSerializedAndDeserialized()
         {  
-            var taskKey = $"{nameof(ItPersistsPropertiesWhenSerializedAndDeserialized)}::{Guid.NewGuid().ToString()}";
+            var taskKey = 
+                new TaskKey($"{nameof(ItPersistsPropertiesWhenSerializedAndDeserialized)}::{Guid.NewGuid().ToString()}");
 
             var testTask = GetTestTask(() => 
                 Console.WriteLine(nameof(ItPersistsPropertiesWhenSerializedAndDeserialized)));
@@ -43,7 +44,7 @@ namespace Gofer.NET.Tests
             var taskInfo1 = GetTestTask(() => TestMethod1("hello world"));
             var taskInfo2 = GetTestTask(() => TestMethod2());
 
-            var taskKey = $"{nameof(ItPersistsPropertiesWhenSerializedAndDeserialized)}::{Guid.NewGuid().ToString()}";
+            var taskKey = new TaskKey($"{nameof(ItPersistsPropertiesWhenSerializedAndDeserialized)}::{Guid.NewGuid().ToString()}");
 
             new RecurringTask(taskInfo1, TimeSpan.FromMinutes(5), taskKey)
                 .IsEquivalent(new RecurringTask(taskInfo1, TimeSpan.FromMinutes(5), taskKey))
@@ -71,7 +72,7 @@ namespace Gofer.NET.Tests
 
             Action differentIdsThrow = () => 
                 new RecurringTask(taskInfo1, TimeSpan.FromMinutes(5), taskKey)
-                    .IsEquivalent(new RecurringTask(taskInfo1, TimeSpan.FromMinutes(5), "anothertaskkey"));
+                    .IsEquivalent(new RecurringTask(taskInfo1, TimeSpan.FromMinutes(5), new TaskKey("anothertaskkey")));
             
             differentIdsThrow.ShouldThrow<Exception>();
         }

--- a/Gofer.NET.Tests/GivenATaskScheduler.cs
+++ b/Gofer.NET.Tests/GivenATaskScheduler.cs
@@ -244,7 +244,7 @@ namespace Gofer.NET.Tests
             var taskQueue = TaskQueueTestFixture.UniqueRedisTaskQueue();
             var taskScheduler = new TaskScheduler(taskQueue);
 
-            (await taskScheduler.CancelTask("hello")).Should().BeFalse();
+            (await taskScheduler.CancelTask(new TaskKey("hello"))).Should().BeFalse();
         }
 
         [Fact]

--- a/RecurringTask.cs
+++ b/RecurringTask.cs
@@ -12,7 +12,7 @@ namespace Gofer.NET
         public string LockKey => $"{nameof(RecurringTask)}::{TaskKey}::ScheduleLock";
 
         [JsonProperty]
-        public string TaskKey { get; private set; }
+        public TaskKey TaskKey { get; private set; }
 
         [JsonProperty]
         public DateTime StartTime { get; private set; }
@@ -34,7 +34,7 @@ namespace Gofer.NET
         public RecurringTask(
             TaskInfo taskInfo,
             TimeSpan interval,
-            string taskKey) : this(taskInfo, taskKey)
+            TaskKey taskKey) : this(taskInfo, taskKey)
         {
             Interval = interval;
 
@@ -44,7 +44,7 @@ namespace Gofer.NET
         public RecurringTask(
             TaskInfo taskInfo,
             string crontab,
-            string taskKey) : this(taskInfo, taskKey)
+            TaskKey taskKey) : this(taskInfo, taskKey)
         {
             ValidateCrontab(crontab);
             Crontab = crontab;
@@ -52,7 +52,7 @@ namespace Gofer.NET
             FirstRunTime = GetNextRunTime(DateTime.UtcNow);
         }
 
-        private RecurringTask(TaskInfo taskInfo, string taskKey)
+        private RecurringTask(TaskInfo taskInfo, TaskKey taskKey)
         {
             TaskInfo = taskInfo;
             StartTime = DateTime.UtcNow;

--- a/ScheduledTask.cs
+++ b/ScheduledTask.cs
@@ -12,7 +12,7 @@ namespace Gofer.NET
         public string LockKey => $"{nameof(ScheduledTask)}::{TaskKey}::ScheduleLock";
 
         [JsonProperty]
-        public string TaskKey { get; private set; }
+        public TaskKey TaskKey { get; private set; }
 
         [JsonProperty]
         public long ScheduledUnixTimeMilliseconds { get; private set; }
@@ -25,7 +25,7 @@ namespace Gofer.NET
         public ScheduledTask(
             TaskInfo taskInfo,
             TimeSpan offset,
-            string taskKey) : this(taskInfo, new DateTimeOffset(DateTime.UtcNow + offset), taskKey)
+            TaskKey taskKey) : this(taskInfo, new DateTimeOffset(DateTime.UtcNow + offset), taskKey)
         {
         }
 
@@ -33,14 +33,14 @@ namespace Gofer.NET
             TaskInfo taskInfo,
             DateTime scheduledTime,
             TaskQueue taskQueue,
-            string taskKey) : this(taskInfo, new DateTimeOffset(scheduledTime), taskKey)
+            TaskKey taskKey) : this(taskInfo, new DateTimeOffset(scheduledTime), taskKey)
         {
         }
 
         public ScheduledTask(
             TaskInfo taskInfo,
             DateTimeOffset scheduledDateTimeOffset,
-            string taskKey)
+            TaskKey taskKey)
         {
             TaskKey = taskKey;
             TaskInfo = taskInfo;

--- a/TaskKey.cs
+++ b/TaskKey.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace Gofer.NET
+{
+    public class TaskKey
+    {
+        public string Value { get; set; }
+
+        public string RecurringTaskName { get; set; }
+
+        public static TaskKey CreateUnique()
+        {
+            return new TaskKey($"{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}::{Guid.NewGuid().ToString()}");
+        }
+
+        public static TaskKey CreateRecurring(string recurringTaskName)
+        {
+            return new TaskKey($"Recurring{nameof(TaskKey)}::{recurringTaskName}", recurringTaskName);
+        }
+
+        public TaskKey(string value)
+        {
+            Value = value;
+            RecurringTaskName = null;
+        }
+
+        public TaskKey(string value, string recurringTaskName)
+        {
+            Value = value;
+            RecurringTaskName = recurringTaskName;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            return string.Equals(Value, ((TaskKey) obj).Value);
+        }
+        
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return Value;
+        }
+    }
+}


### PR DESCRIPTION
Convert the TaskKey to be a TaskKey object.

Purpose of this change is to give better specification to the difference between a TaskKey and a task name.