### PR TITLE
Upgrade redis dependency to new package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ matrix:
       dist: trusty
     - os: osx
       osx_image: xcode10.2
+      cache:
+      directories:
+      - "/Users/travis/Library/Caches/Homebrew/"
+      - "$HOME/.nuget"
 
 branches:
   only:

--- a/Gofer.NET.csproj
+++ b/Gofer.NET.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="NCrontab" Version="3.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" />
+    <PackageReference Include="StackExchange.Redis" Version="2.0.600" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="Gofer.NET.Utils\Gofer.NET.Utils.csproj" />


### PR DESCRIPTION
Accommodating a breaking change on `StackExchange.Redis` side.

See Release Notes: https://stackexchange.github.io/StackExchange.Redis/ReleaseNotes#20495