### PR TITLE
Add cancellation token support

### DIFF
--- a/Gofer.NET.Tests/GivenATaskClient.cs
+++ b/Gofer.NET.Tests/GivenATaskClient.cs
@@ -3,8 +3,9 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
 using FluentAssertions;
-using Gofer.NET.Utils;
+
 using Xunit;
 
 namespace Gofer.NET.Tests
@@ -15,11 +16,11 @@ namespace Gofer.NET.Tests
         public async Task ItContinuesListeningWhenATaskThrowsAnException()
         {
             var waitTime = 5000;
-            
+
             var taskQueue = TaskQueueTestFixture.UniqueRedisTaskQueue();
             var taskClient = new TaskClient(taskQueue);
             var semaphoreFile = Path.GetTempFileName();
-            
+
             await taskClient.TaskQueue.Enqueue(() => Throw());
             await taskClient.TaskQueue.Enqueue(() => TaskQueueTestFixture.WriteSemaphore(semaphoreFile));
 
@@ -28,7 +29,29 @@ namespace Gofer.NET.Tests
 
             taskClient.CancelListen();
             await task;
-            
+
+            TaskQueueTestFixture.EnsureSemaphore(semaphoreFile);
+        }
+
+        [Fact]
+        public async Task ItStopsOnCancellation()
+        {
+            var semaphoreFile = Path.GetTempFileName();
+
+            var waitTime = 2000;
+
+            var taskQueue = TaskQueueTestFixture.UniqueRedisTaskQueue();
+            var taskClient = new TaskClient(taskQueue);
+            var cancellation = new CancellationTokenSource();
+
+            await taskClient.TaskQueue.Enqueue(() => TaskQueueTestFixture.WaitForCancellationAndWriteSemaphore(semaphoreFile, default));
+
+            var task = Task.Run(async () => await taskClient.Listen(cancellation.Token), CancellationToken.None);
+            await Task.Delay(waitTime, CancellationToken.None);
+            cancellation.Cancel();
+            await Task.Delay(waitTime, CancellationToken.None);
+            await task;
+
             TaskQueueTestFixture.EnsureSemaphore(semaphoreFile);
         }
 
@@ -36,14 +59,14 @@ namespace Gofer.NET.Tests
         public async Task ItDoesNotDelayScheduledTaskPromotionWhenRunningLongTasks()
         {
             var waitTime = 4000;
-            
+
             var taskQueue = TaskQueueTestFixture.UniqueRedisTaskQueue();
             var taskClient = new TaskClient(taskQueue);
 
             var semaphoreFile = Path.GetTempFileName();
             File.Delete(semaphoreFile);
             File.Exists(semaphoreFile).Should().BeFalse();
-            
+
             await taskClient.TaskQueue.Enqueue(() => Wait(waitTime));
 
             await taskClient.TaskScheduler.AddScheduledTask(
@@ -51,14 +74,14 @@ namespace Gofer.NET.Tests
                 TimeSpan.FromMilliseconds(waitTime / 4));
 
             var task = Task.Run(async () => await taskClient.Listen());
-            
+
             await Task.Delay(waitTime / 2);
 
             // Ensure we did not run the scheduled task
             File.Exists(semaphoreFile).Should().BeFalse();
 
             var dequeuedScheduledTask = await taskQueue.Dequeue();
-            
+
             File.Exists(semaphoreFile).Should().BeFalse();
             dequeuedScheduledTask.Should().NotBeNull();
             dequeuedScheduledTask.MethodName.Should().Be(nameof(TaskQueueTestFixture.WriteSemaphore));
@@ -83,19 +106,19 @@ namespace Gofer.NET.Tests
             File.Delete(semaphoreFile);
             File.Exists(semaphoreFile).Should().BeFalse();
 
-            for (var i=0; i<immediateTasks; ++i)
+            for (var i = 0; i < immediateTasks; ++i)
             {
-                await taskClient.TaskQueue.Enqueue(() => 
-                    TaskQueueTestFixture.WriteSemaphoreValue(semaphoreFile, (i+1).ToString()));
+                await taskClient.TaskQueue.Enqueue(() =>
+                    TaskQueueTestFixture.WriteSemaphoreValue(semaphoreFile, (i + 1).ToString()));
             }
 
-            for (var i=0; i<scheduledTasks; ++i)
+            for (var i = 0; i < scheduledTasks; ++i)
             {
                 await taskClient.TaskScheduler.AddScheduledTask(
-                    () => TaskQueueTestFixture.WriteSemaphoreValue(semaphoreFile, (immediateTasks+i+1).ToString()),
-                    TimeSpan.FromMilliseconds(scheduledTasksStart + (scheduledTasksIncrement*i)));
+                    () => TaskQueueTestFixture.WriteSemaphoreValue(semaphoreFile, (immediateTasks + i + 1).ToString()),
+                    TimeSpan.FromMilliseconds(scheduledTasksStart + (scheduledTasksIncrement * i)));
             }
-            
+
             var task = Task.Run(async () => await taskClient.Listen());
             Thread.Sleep(scheduledTasks * scheduledTasksIncrement + 2000);
 

--- a/Gofer.NET.Utils/ActionExtensionMethods.cs
+++ b/Gofer.NET.Utils/ActionExtensionMethods.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
 
 namespace Gofer.NET.Utils
 {
@@ -11,15 +12,15 @@ namespace Gofer.NET.Utils
         {
             var methodCallArgumentResolutionVisitor = new MethodCallArgumentResolutionVisitor();
             var expressionWithArgumentsResolved =
-                (Expression<Action>) methodCallArgumentResolutionVisitor.Visit(expression);
+                (Expression<Action>)methodCallArgumentResolutionVisitor.Visit(expression);
 
-            var method = ((MethodCallExpression) expressionWithArgumentsResolved.Body);
+            var method = ((MethodCallExpression)expressionWithArgumentsResolved.Body);
             var m = method.Method;
             var args = method.Arguments
                 .Select(a =>
                 {
-                    var value = ((ConstantExpression) a).Value;
-                    return value;
+                    var value = ((ConstantExpression)a).Value;
+                    return value is CancellationToken ? null : value;
                 })
                 .ToArray();
 
@@ -27,20 +28,20 @@ namespace Gofer.NET.Utils
 
             return taskInfo;
         }
-        
+
         public static TaskInfo ToTaskInfo<T>(this Expression<Func<T>> expression)
         {
             var methodCallArgumentResolutionVisitor = new MethodCallArgumentResolutionVisitor();
             var expressionWithArgumentsResolved =
-                (Expression<Func<T>>) methodCallArgumentResolutionVisitor.Visit(expression);
+                (Expression<Func<T>>)methodCallArgumentResolutionVisitor.Visit(expression);
 
-            var method = ((MethodCallExpression) expressionWithArgumentsResolved.Body);
+            var method = ((MethodCallExpression)expressionWithArgumentsResolved.Body);
             var m = method.Method;
             var args = method.Arguments
                 .Select(a =>
                 {
-                    var value = ((ConstantExpression) a).Value;
-                    return value;
+                    var value = ((ConstantExpression)a).Value;
+                    return value is CancellationToken ? null : value;
                 })
                 .ToArray();
 
@@ -48,13 +49,13 @@ namespace Gofer.NET.Utils
 
             return taskInfo;
         }
-        
+
         public static TaskInfo ToTaskInfo(this MethodInfo method, object[] args)
         {
             var methodParams = method.GetParameters();
             var argTypes = new Type[methodParams.Length];
-            
-            for (var i=0; i < methodParams.Length; ++ i)
+
+            for (var i = 0; i < methodParams.Length; ++i)
             {
                 argTypes[i] = methodParams[i].ParameterType;
             }
@@ -70,7 +71,7 @@ namespace Gofer.NET.Utils
                 CreatedAtUtc = DateTime.UtcNow,
                 ReturnType = method.ReturnType
             };
-            
+
             return taskInfo;
         }
     }

--- a/Gofer.NET.Utils/JsonSkipCancellationTokenConverter.cs
+++ b/Gofer.NET.Utils/JsonSkipCancellationTokenConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading;
+
+using Newtonsoft.Json;
+
+namespace Gofer.NET.Utils
+{
+    public class JsonSkipCancellationTokenConverter : JsonConverter
+    {
+        public override bool CanRead => false;
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(CancellationToken);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteValue((object)null);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Gofer.NET.Utils/JsonTaskInfoSerializer.cs
+++ b/Gofer.NET.Utils/JsonTaskInfoSerializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿
 using Newtonsoft.Json;
 
 namespace Gofer.NET.Utils
@@ -7,7 +7,7 @@ namespace Gofer.NET.Utils
     {
         public static string Serialize(TaskInfo taskInfo)
         {
-            return Serialize((object) taskInfo);
+            return Serialize((object)taskInfo);
         }
 
         public static string Serialize(object obj)
@@ -20,7 +20,8 @@ namespace Gofer.NET.Utils
 
             settings.Converters.Insert(0, new JsonPrimitiveConverter());
             settings.Converters.Insert(1, new ExceptionConverter());
-            
+            settings.Converters.Insert(2, new JsonSkipCancellationTokenConverter());
+
             var jsonString = JsonConvert.SerializeObject(obj, settings);
 
             return jsonString;
@@ -30,21 +31,23 @@ namespace Gofer.NET.Utils
         {
             return Deserialize<TaskInfo>(taskInfoJsonString);
         }
-        
-        public static T Deserialize<T>(string jsonString) where T : class 
+
+        public static T Deserialize<T>(string jsonString) where T : class
         {
             if (jsonString == null)
             {
                 return null;
             }
-            
+
             var settings = new JsonSerializerSettings
             {
                 TypeNameHandling = TypeNameHandling.All,
                 TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Full
             };
+
             settings.Converters.Insert(0, new JsonPrimitiveConverter());
             settings.Converters.Insert(1, new ExceptionConverter());
+            settings.Converters.Insert(2, new JsonSkipCancellationTokenConverter());
 
             var obj = JsonConvert.DeserializeObject<T>(jsonString, settings);
             return obj;

--- a/TaskClient.cs
+++ b/TaskClient.cs
@@ -1,21 +1,19 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
-using Gofer.NET.Errors;
+
 using Gofer.NET.Utils;
-using Newtonsoft.Json;
 
 namespace Gofer.NET
 {
     public class TaskClient
     {
         private static readonly object Locker = new object();
-        
+
         private const int PollDelay = 100;
 
         private bool IsCanceled { get; set; }
-        
+
         public TaskQueue TaskQueue { get; }
 
         public Action<Exception> OnError { get; }
@@ -29,8 +27,8 @@ namespace Gofer.NET
         private CancellationTokenSource ListenCancellationTokenSource { get; set; }
 
         public TaskClient(
-            TaskQueue taskQueue, 
-            Action<Exception> onError=null)
+            TaskQueue taskQueue,
+            Action<Exception> onError = null)
         {
             TaskQueue = taskQueue;
             OnError = onError;
@@ -38,26 +36,38 @@ namespace Gofer.NET
             IsCanceled = false;
         }
 
-        public async Task Listen()
+        public Task Listen()
         {
-            Start();
+            return Listen(CancellationToken.None);
+        }
 
-            await Task.WhenAll(new [] {
-                TaskRunnerThread, 
+        public async Task Listen(CancellationToken cancellation)
+        {
+            Start(cancellation);
+
+            await Task.WhenAll(new[] {
+                TaskRunnerThread,
                 TaskSchedulerThread});
         }
 
         public CancellationTokenSource Start()
+        {
+            return Start(CancellationToken.None);
+        }
+
+        public CancellationTokenSource Start(CancellationToken cancellation)
         {
             if (TaskSchedulerThread != null || TaskRunnerThread != null)
             {
                 throw new Exception("This TaskClient is already listening.");
             }
 
-            ListenCancellationTokenSource = new CancellationTokenSource();
+
+            ListenCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
             var token = ListenCancellationTokenSource.Token;
 
-            TaskSchedulerThread = Task.Run(async () => {
+            TaskSchedulerThread = Task.Run(async () =>
+            {
                 var inThreadTaskScheduler = new TaskScheduler(TaskQueue);
 
                 while (true)
@@ -71,22 +81,23 @@ namespace Gofer.NET
                 }
             }, ListenCancellationTokenSource.Token);
 
-            TaskRunnerThread = Task.Run(async () => {
+            TaskRunnerThread = Task.Run(async () =>
+            {
                 while (true)
                 {
                     if (token.IsCancellationRequested)
                     {
                         return;
                     }
-                    
-                    await ExecuteQueuedTask();
+
+                    await ExecuteQueuedTask(token);
                 }
             }, ListenCancellationTokenSource.Token);
 
             return ListenCancellationTokenSource;
         }
 
-        private async Task ExecuteQueuedTask()
+        private async Task ExecuteQueuedTask(CancellationToken token)
         {
             var (json, info) = await TaskQueue.SafeDequeue();
             if (info != null)
@@ -96,9 +107,9 @@ namespace Gofer.NET
                 try
                 {
                     var now = DateTime.Now;
-                    
-                    await info.ExecuteTask();
-                    
+
+                    await info.ExecuteTask(token);
+
                     var completionSeconds = (DateTime.Now - now).TotalSeconds;
                     LogTaskFinished(info, completionSeconds);
                 }
@@ -122,7 +133,7 @@ namespace Gofer.NET
             var logMessage = Messages.TaskStarted(info);
             ThreadSafeColoredConsole.Info(logMessage);
         }
-        
+
         private void LogTaskFinished(TaskInfo info, double completionSeconds)
         {
             var logMessage = Messages.TaskFinished(info, completionSeconds);

--- a/TaskQueue.cs
+++ b/TaskQueue.cs
@@ -35,7 +35,13 @@ namespace Gofer.NET
             var taskInfo = expression.ToTaskInfo();
             await Enqueue(taskInfo);
         }
-        
+
+        public async Task Enqueue<T>(Expression<Func<T>> expression)
+        {
+            var taskInfo = expression.ToTaskInfo();
+            await Enqueue(taskInfo);
+        }
+
         internal async Task Enqueue(TaskInfo taskInfo)
         {
             taskInfo.ConvertTypeArgs();
@@ -43,8 +49,8 @@ namespace Gofer.NET
 
             await Backend.Enqueue(Config.QueueName, jsonString);
         }
-        
-        public async Task<bool> ExecuteNext()
+
+        public async Task<bool> ExecuteNext(CancellationToken cancellation = default)
         {
             var (taskJsonString, taskInfo) = await SafeDequeue();
 
@@ -55,7 +61,7 @@ namespace Gofer.NET
 
             try
             {
-                await taskInfo.ExecuteTask();
+                await taskInfo.ExecuteTask(cancellation);
             }
             finally
             {


### PR DESCRIPTION
This PR
1. Adds cancellation token support for TaskClient Listen()/Start() methods.
2. Adds cancellation support for enqueued tasks.
   * ToTaskInfo() replaces CancellationTokenArgs with nulls
   * I've added JsonSkipCancellationTokenConverter to ensure same logic will be applied even if the `TaskInfo` is created manually
   * The InvokeMethod() method accepts CancellationToken arg and replaces target method cancellation arg with the passed token.

Tests included.